### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='testflo',
       version='1.2',


### PR DESCRIPTION
install_requires and entry_points are actually attributes of setuptools, so installing with "setup.py install" won't work correctly without the change.