### PR TITLE
Fix Testcase Class Setup/Teadown w/ MPI

### DIFF
--- a/testflo/mpirun.py
+++ b/testflo/mpirun.py
@@ -29,6 +29,8 @@ if __name__ == '__main__':
             comm = MPI.COMM_WORLD
             test = Test(sys.argv[1])
             test.nocapture = True # so we don't lose stdout
+            test._tcase_fixture_first = True
+            test._tcase_fixture_last = True
             test.run()
         except:
             print(traceback.format_exc())


### PR DESCRIPTION
testflo sets `_tcase_fixture_first` and `_tcase_fixture_last` to its intended state during the [test case discovery][0]. This way, testflo ensures `setUpClass()` and `tearDownClass()` is only called for first or last test in a test class, respectively.

With MPI enabled, each test is run in its own process wich [instantiates new test instances][1] where these attributes are kept at their default value (`False`). So `setUpClass` and `tearDownClass` are never executed.

Furthermore, as each test is run in its own process, and thus with an freshly initialized Python interpreter, it makes more sense to run these methods for every test.

[0]: https://github.com/naylor-b/testflo/blob/master/testflo/discover.py#L67
[1]: https://github.com/naylor-b/testflo/blob/master/testflo/mpirun.py#L30